### PR TITLE
Fix _CRT_SECURE_NO_WARNINGS

### DIFF
--- a/routine.h
+++ b/routine.h
@@ -21,6 +21,10 @@
 #define UMDF_USING_NTSTATUS
 #endif // !UMDF_USING_NTSTATUS
 
+#if !defined(_UCRT_DISABLED_WARNINGS)
+#define _UCRT_DISABLED_WARNINGS 4996 //_CRT_SECURE_NO_WARNINGS
+#endif // !_UCRT_DISABLED_WARNINGS
+
 // crt
 #include <assert.h>
 #include <inttypes.h>


### PR DESCRIPTION
I have Windows 10 SDK (10.0.18362.0 and below), used visual studio 2019 latest version (16.11.1) and got the following errors

```
1>D:\Downloads\henrypp\routine\routine.c(52,26): error C2220: the following warning is treated as an error
1>D:\Downloads\henrypp\routine\routine.c(52,26): warning C4083: expected ')'; found identifier '_UCRT_DISABLED_WARNINGS'
1>D:\Downloads\henrypp\routine\routine.c(53,2): error C4996: '_vsnwprintf': This function or variable may be unsafe. Consider using _vsnwprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>D:\Downloads\henrypp\routine\routine.c(1918,26): warning C4083: expected ')'; found identifier '_UCRT_DISABLED_WARNINGS'
1>D:\Downloads\henrypp\routine\routine.c(1919,2): error C4996: '_vsnwprintf': This function or variable may be unsafe. Consider using _vsnwprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>D:\Downloads\henrypp\routine\routine.c(1972,26): warning C4083: expected ')'; found identifier '_UCRT_DISABLED_WARNINGS'
1>D:\Downloads\henrypp\routine\routine.c(1973,2): error C4996: '_vsnwprintf': This function or variable may be unsafe. Consider using _vsnwprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
1>D:\Downloads\henrypp\routine\routine.c(3826,26): warning C4083: expected ')'; found identifier '_UCRT_DISABLED_WARNINGS'
1>D:\Downloads\henrypp\routine\routine.c(3827,20): error C4996: '_vsnwprintf': This function or variable may be unsafe. Consider using _vsnwprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
```