### PR TITLE
Fix of ListView items dupe on settings reset (REQUIREMENT)

### DIFF
--- a/src/routine.h
+++ b/src/routine.h
@@ -5586,6 +5586,16 @@ FORCEINLINE BOOLEAN _r_listview_deleteallitems (
 	return (_r_wnd_sendmessage (hwnd, ctrl_id, LVM_DELETEALLITEMS, 0, 0) == TRUE);
 }
 
+FORCEINLINE VOID _r_listview_reset (
+	_In_ HWND hwnd,
+	_In_opt_ INT ctrl_id
+)
+{
+	_r_listview_deleteallitems(hwnd, ctrl_id);
+	_r_listview_deleteallgroups(hwnd, ctrl_id);
+	_r_listview_deleteallcolumns(hwnd, ctrl_id);
+}
+
 FORCEINLINE BOOLEAN _r_listview_deleteitem (
 	_In_ HWND hwnd,
 	_In_opt_ INT ctrl_id,


### PR DESCRIPTION
this is not a fix directly, instead here a small inline function, that's required for actual fix ( henrypp/memreduct#270 )

i add this function here for overall consistency and easy fix of this issue(if any) in other projects that depend on this SDK